### PR TITLE
CRYS-769: PHP: Shadow and Opcache don't work well together

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -1,1 +1,3 @@
 Stas Malyshev smalyshev@sugarcrm.com
+Michael Gusev mgusev@sugarcrm.com
+Dmitry Duca dduca@sugarcrm.com

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ PHP module
 Shadow is implemented as PHP extension. Compile it using:
 
 ```bash
-/path/to/php/install/bin/phpize
-./configure --with-php-config=/path/to/php/install/bin/php-config
+phpize
+./configure --with-php-config=php-config
 make
 make install
 make test
@@ -80,7 +80,7 @@ DEBUG_CHMOD        (1<<11)  4096
 DEBUG_OVERRIDE     (1<<12)  8192
 ```
 
-For enable all DEBUG message shadow.xdebug must be equal 8191
+For enable all DEBUG message shadow.debug must be equal 8191
 
 Sugar Module
 ============

--- a/php-shadow.spec
+++ b/php-shadow.spec
@@ -3,7 +3,7 @@
 %global php_version %(php-config --version 2>/dev/null || echo 0)
 
 Name:           php-shadow
-Version:        0.3.11
+Version:        0.3.12
 Release:        1sugar
 Summary:        Shadow is a multitenancy-support module for Sugar
 
@@ -46,6 +46,8 @@ rm -rf $RPM_BUILD_ROOT
 %{php_extdir}/shadow.so
 
 %changelog
+* Fri May 22 2015 Michael Gusev <mgusev@sugarcrm.com> - 0.3.12
+- Enabling shadow_resolve_path to support correct behavior with opcache
 * Wed Feb 27 2013 Stas Malyshev <smalyshev@sugarcrm.com> - 0.3.11
 - Fix treating dirs ending on /
 * Mon Feb 25 2013 Stas Malyshev <smalyshev@sugarcrm.com> - 0.3.10

--- a/php_shadow.h
+++ b/php_shadow.h
@@ -69,7 +69,7 @@ ZEND_END_MODULE_GLOBALS(shadow)
 #define SHADOW_G(v) (shadow_globals.v)
 #endif
 
-#define SHADOW_VERSION "0.3.11"
+#define SHADOW_VERSION "0.3.12"
 
 ZEND_EXTERN_MODULE_GLOBALS(shadow)
 


### PR DESCRIPTION
Added support for own path resolver.
it tries to detect shadowed path and if that was detected then processes it throw original resolver to support other overrides.
Also version incremented to 0.3.12.
