### PR TITLE
Minor changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,3 +293,6 @@ opcache.revalidate_freq = 0
 opcache.revalidate_path = On
 ```
 
+Current directory (CWD) should always point to template directory When you use shadow.
+
+

--- a/sugarcrm/shadow.ini
+++ b/sugarcrm/shadow.ini
@@ -8,7 +8,7 @@ extension=shadow.so
 shadow.mkdir_mask=0750
 
 ; Override function
-shadow.override=imagepng@w1,finfo_file@1,ext2mime@0,mime_content_type@0,ziparchive::open@w0,ziparchive::addfile@0,tempnam@w0
+shadow.override=imagepng@w1,finfo_file@1,ext2mime@0,mime_content_type@0,ziparchive::open@w0,ziparchive::addfile@0,tempnam@w0,chdir@0
 
 ; Shadow debug, 8191 - this number enable all debug options.
 ; Messages send to std err or apache error.log.


### PR DESCRIPTION
- It looks like the reason is that chdir() is not overridden by default. Adding shadow.override = chdir@0 to the configuration fixes the problem.
- It looks like the reason is that the functions used in sugar_file_put_contents_atomic() are not overridden by default. Adding shadow.override = imagepng@w1,finfo_file@1,ext2mime@0,mime_content_type@0,ziparchive:open@w0,ziparchive:addfile@0,tempnam@w0,chdir@0 to the configuration fixes the problem.
- I think the only thing needed at this point is a README update with this fact would be useful for other folks down the road since we've switched the CWD requirement from implicit to explicit. Other than that, there's nothing else needing done on this ticket.
