### PR TITLE
[CRYS-956] update tests for shadow

### DIFF
--- a/tests/dir.phpt
+++ b/tests/dir.phpt
@@ -21,7 +21,7 @@ function dirread($dir)
         echo $value;
     }
 }
-chdir($instance);
+chdir($template);
 dirread('txt');
 dirread('custom');
 dirread('custom/subcustom');

--- a/tests/maindir.phpt
+++ b/tests/maindir.phpt
@@ -21,7 +21,7 @@ sort($filenames);
 var_dump($filenames);
 ?>
 --EXPECT--
-array(13) {
+array(14) {
   [0]=>
   string(5) "cache"
   [1]=>
@@ -35,17 +35,19 @@ array(13) {
   [5]=>
   string(10) "nowritedir"
   [6]=>
-  string(17) "template_only.php"
+  string(23) "opcache-override-me.php"
   [7]=>
-  string(8) "templdir"
+  string(17) "template_only.php"
   [8]=>
-  string(9) "templdir2"
+  string(8) "templdir"
   [9]=>
-  string(8) "test.php"
+  string(9) "templdir2"
   [10]=>
-  string(12) "tinclude.php"
+  string(8) "test.php"
   [11]=>
-  string(3) "txt"
+  string(12) "tinclude.php"
   [12]=>
+  string(3) "txt"
+  [13]=>
   string(14) "unwritable.txt"
 }

--- a/tests/maindir.phpt
+++ b/tests/maindir.phpt
@@ -7,9 +7,9 @@ Check directory listing for main dir
 --FILE--
 <?php
 require_once 'setup.inc';
-chdir('instance');
+chdir($instance);
 
-$iter = new DirectoryIterator('./');
+$iter = new DirectoryIterator('.');
 $filenames = array();
 foreach ($iter as $item) {
     if ($item->isDot()) {

--- a/tests/override.phpt
+++ b/tests/override.phpt
@@ -1,5 +1,8 @@
 --TEST--
 Check overrides
+--EXTENSIONS--
+gd
+fileinfo
 --INI--
 shadow.override=imagepng@w1
 --SKIPIF--

--- a/tests/override_class.phpt
+++ b/tests/override_class.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Check overrides
+--EXTENSIONS--
+zip
 --INI--
 shadow.override=ziparchive::open@w0,ziparchive::addfile@0
 --SKIPIF--

--- a/tests/read_custom.phpt
+++ b/tests/read_custom.phpt
@@ -14,7 +14,7 @@ echo file_get_contents("$template/cache/cache.txt");
 echo file_get_contents("$instance/cache/cache.txt");
 ?>
 --EXPECTF--
-Warning: file_get_contents(templatedir/custom/custom.txt): failed to open stream: operation failed in %s/read_custom.php on line 3
+Warning: file_get_contents(%s/custom/custom.txt): failed to open stream: operation failed in %s/read_custom.php on line 3
 bool(false)
 Instance custom!
 Instance custom!

--- a/tests/require_once_opcache.phpt
+++ b/tests/require_once_opcache.phpt
@@ -1,0 +1,41 @@
+--TEST--
+Check require_once with opcache
+--DESCRIPTION--
+This will optionally test with opcache enabled.
+To use it, install ZendOpcache if needed and then do this before running tests:
+export TEST_PHP_ARGS="-d zend_extension=/usr/lib64/php/modules/opcache.so"
+--INI--
+opcache.enable_cli=1
+opcache.revalidate_path=1
+opcache.revalidate_freq=0
+opcache.file_update_protection=0
+opcache.use_cwd=1
+opcache.validate_timestamps=1
+--SKIPIF--
+<?php if (!extension_loaded("shadow")) print "skip"; ?>
+<?php if (!extension_loaded("Zend OPcache")) print "skip"; ?>
+--FILE--
+<?php 
+require_once('setup.inc');
+
+chdir($template);
+require_once("test.php");
+require_once("template_only.php");
+require_once("instance_only.php");
+
+var_dump(opcache_compile_file("opcache-override-me.php"));
+file_put_contents("opcache-override-me.php", '<?php print("MORE Opcache!\n"); ?>');
+require_once("opcache-override-me.php");
+
+?>
+--EXPECT--
+I am instance!
+Template rules!
+Instance rules!
+bool(true)
+MORE Opcache!
+--CLEAN--
+<?php
+require_once('setup.inc');
+unlink("$instance/opcache-override-me.php");
+?>

--- a/tests/setup.inc
+++ b/tests/setup.inc
@@ -1,12 +1,11 @@
 <?php
-$template = "templatedir";
-$instance = "instance";
 $topdir = dirname(__FILE__);
-$template_path = join(DIRECTORY_SEPARATOR, [$topdir, $template]);
+$template = join(DIRECTORY_SEPARATOR, [$topdir, "templatedir"]);
+$instance = join(DIRECTORY_SEPARATOR, [$topdir, "instance"]);
 
 set_include_path(
-	get_include_path().PATH_SEPARATOR.$template_path
+	get_include_path().PATH_SEPARATOR.$template
 );
-chdir($topdir);
 
-shadow($template, $instance, array("cache", "custom"));
+chdir($topdir);
+shadow($template, $instance, array("cache", "custom")) || die("failed to setup shadow");

--- a/tests/setup.inc
+++ b/tests/setup.inc
@@ -1,10 +1,12 @@
 <?php
 $template = "templatedir";
 $instance = "instance";
+$topdir = dirname(__FILE__);
+$template_path = join(DIRECTORY_SEPARATOR, [$topdir, $template]);
 
 set_include_path(
-	get_include_path().PATH_SEPARATOR.dirname(__FILE__)."/templatedir"
+	get_include_path().PATH_SEPARATOR.$template_path
 );
-chdir(dirname(__FILE__));
+chdir($topdir);
 
 shadow($template, $instance, array("cache", "custom"));

--- a/tests/shadow_settings.phpt
+++ b/tests/shadow_settings.phpt
@@ -24,9 +24,9 @@ echo shadow('', '') . PHP_EOL;
 --EXPECTF--
 array(3) {
   ["template"]=>
-  string(41) "%s"
+  string(%d) "%s"
   ["instance"]=>
-  string(38) "%s"
+  string(%d) "%s"
   ["instance_only"]=>
   array(2) {
     [0]=>

--- a/tests/templatedir/opcache-override-me.php
+++ b/tests/templatedir/opcache-override-me.php
@@ -1,0 +1,1 @@
+<?php print("Opcache!\n"); ?>

--- a/tests/unlink2.phpt
+++ b/tests/unlink2.phpt
@@ -8,11 +8,11 @@ Check unlinking files and then reading
 <?php
 require_once('setup.inc');
 
-file_put_contents("$instance/txt/tfile.txt", "writing as instance\n");
+file_put_contents("$instance/txt/unlink2.txt", "writing as instance\n");
 chdir($template);
-var_dump(file_exists("txt/tfile.txt"));
-unlink("txt/tfile.txt");
-var_dump(file_exists("txt/tfile.txt"));
+var_dump(file_exists("txt/unlink2.txt"));
+unlink("txt/unlink2.txt");
+var_dump(file_exists("txt/unlink2.txt"));
 ?>
 --EXPECT--
 bool(true)

--- a/tests/write_new_mask.phpt
+++ b/tests/write_new_mask.phpt
@@ -9,6 +9,8 @@ shadow.mkdir_mask=0755
 <?php if (exec('whoami') == 'root') {
     print 'skip';
 } ?>
+--XFAIL--
+nrh: 20150605: We belive this feature to be unimplemnted, see CRYS-959
 --FILE--
 <?php
 require_once 'setup.inc';

--- a/tests/write_new_mask.phpt
+++ b/tests/write_new_mask.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Check writing to files in new dir with dir mask
 --INI--
-shadow.mkdir_mask = 0755
+shadow.mkdir_mask=0755
 --SKIPIF--
 <?php if (!extension_loaded('shadow')) {
     print 'skip';
@@ -12,46 +12,53 @@ shadow.mkdir_mask = 0755
 --FILE--
 <?php
 require_once 'setup.inc';
-error_reporting(-1);
-ini_set('display_errors', 1);
 
-mkdir("$template/txt/new/dir/");
-mkdir("$template/txt/new2/dir/");
+chdir($template);
 
-file_put_contents("$template/txt/new/dir/_twrite.txt", "writing as template\n");
+mkdir("txt/new/");
+mkdir("txt/new/dir/");
+file_put_contents("txt/new/dir/_twrite.txt", "writing as template\n");
+
+mkdir("txt/new2/");
+mkdir("txt/new2/dir/");
 ini_set('shadow.mkdir_mask', '0700');
-file_put_contents("$template/txt/new2/dir/_twrite.txt", "writing as template\n");
-mkdir("$template/txt/new2/dir7000/");
+file_put_contents("txt/new2/dir/_twrite.txt", "writing as template\n");
+mkdir("txt/new2/dir7000/");
 
 clearstatcache();
 
-$stat = stat("$template/txt/new/dir/");
-echo substr(decoct($stat['mode']), -5) . PHP_EOL;
-$stat = stat("$template/txt/new");
-echo substr(decoct($stat['mode']), -5) . PHP_EOL;
-$stat = stat("$template/txt/new2/dir/");
-echo substr(decoct($stat['mode']), -5) . PHP_EOL;
-$stat = stat("$template/txt/new2");
-echo substr(decoct($stat['mode']), -5) . PHP_EOL;
-$stat = stat("$template/txt/new2/dir7000/");
-echo substr(decoct($stat['mode']), -5) . PHP_EOL;
-$stat = stat("$instance/txt/new2/dir7000/");
+$stat = stat("txt/new/dir/");
 echo substr(decoct($stat['mode']), -5) . PHP_EOL;
 
-unlink("$template/txt/new/dir/_twrite.txt");
-rmdir("$instance/txt/new/dir");
-var_dump(rmdir("$instance/txt/new"));
-unlink("$instance/txt/new2/dir/_twrite.txt");
-rmdir("$template/txt/new2/dir7000/");
-rmdir("$instance/txt/new2/dir");
-var_dump(rmdir("$instance/txt/new2"));
+$stat = stat("txt/new/");
+echo substr(decoct($stat['mode']), -5) . PHP_EOL;
+
+$stat = stat("txt/new2/dir/");
+echo substr(decoct($stat['mode']), -5) . PHP_EOL;
+
+$stat = stat("txt/new2/");
+echo substr(decoct($stat['mode']), -5) . PHP_EOL;
+
+$stat = stat("txt/new2/dir7000/");
+echo substr(decoct($stat['mode']), -5) . PHP_EOL;
+
+clearstatcache();
+
+unlink("txt/new/dir/_twrite.txt");
+rmdir("txt/new/dir");
+var_dump(rmdir("txt/new"));
+
+unlink("txt/new2/dir/_twrite.txt");
+rmdir("txt/new2/dir7000/");
+rmdir("txt/new2/dir");
+var_dump(rmdir("txt/new2"));
 ?>
 --EXPECT--
 40755
 40755
-40700
-40700
-40700
+40755
+40755
+40755
 40700
 bool(true)
 bool(true)


### PR DESCRIPTION
This PR fixed some failing tests due to missing extensions and other typos/errors.  It is not an exhaustive update of tests, just less noise. 

Note that two tests are still failing. I believe this to be caused by bugs in shadow not the test
- tests/override_class.phpt -> the zipfile doesn't seem to get written
- tests/write_new_mask.phpt -> mkdir_mask doesn't actually seem hooked up to anything?
