### PR TITLE
PHP 8.0: Fixed PHP 8.0 compilation issues.

### DIFF
--- a/shadow_cache.h
+++ b/shadow_cache.h
@@ -5,8 +5,8 @@
  *  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-void shadow_cache_set_id(zend_string *template, zend_string *instance TSRMLS_DC);
-int shadow_cache_get(const char *name, char **entry TSRMLS_DC);
-void shadow_cache_put(const char *name, const char *entry TSRMLS_DC);
-void shadow_cache_remove(const char *name TSRMLS_DC);
-void shadow_cache_clean(TSRMLS_D);
+void shadow_cache_set_id(zend_string *template, zend_string *instance);
+int shadow_cache_get(const char *name, char **entry);
+void shadow_cache_put(const char *name, const char *entry);
+void shadow_cache_remove(const char *name);
+void shadow_cache_clean();

--- a/tests/read_custom.phpt
+++ b/tests/read_custom.phpt
@@ -14,7 +14,7 @@ echo file_get_contents("$template/cache/cache.txt");
 echo file_get_contents("$instance/cache/cache.txt");
 ?>
 --EXPECTF--
-Warning: file_get_contents(%s/custom/custom.txt): failed to open stream: operation failed in %s/read_custom.php on line 3
+Warning: file_get_contents(%s/custom/custom.txt): Failed to open stream: operation failed in %s/read_custom.php on line 3
 bool(false)
 Instance custom!
 Instance custom!


### PR DESCRIPTION
Hi guys,

Took a look at the shadow issues with compiling on PHP 8.0.
Issue seemed to be some definition macros that got removed in 8.0 since apparently they are not needed anymore. 
They generally make ZTS/non-ZTS cross compilation easily and generally evaluate to nothing for non-ZTS compiles. 

More info here: http://blog.golemon.com/2006/06/what-heck-is-tsrmlscc-anyway.html

Also, had to create an additional arginfo type (arginfo_void) to replace the NULL in the function definition section. The nulls were throwing off warnings in the test executions.

Ran the tests and they were fine on my machine, but yeah, will probably need a hell of a lot more review.

Also, I know that theoretically I'm missing a few things in this pull request (such as an issue ID, but couldn't find a JIRA ticket for this job). Just let me know what I need to groom here and I'll do it :) 

Regards,
Ionut Tonita